### PR TITLE
Add commit ID and full commit message to Jenkins changelog

### DIFF
--- a/lib/fastlane/plugin/ci_changelog/helper/ci_changelog_helper.rb
+++ b/lib/fastlane/plugin/ci_changelog/helper/ci_changelog_helper.rb
@@ -17,8 +17,10 @@ module Fastlane
         # TODO: It must use reverse_each to correct the changelog
         commit = json['changeSet']['items'].each_with_object([]) do |item, obj|
           obj.push({
+            id: item['commitId'],
             date: item['date'],
-            message: item['msg'],
+            title: item['msg'],
+            message: item['comment'],
             author: item['author']['fullName'].strip,
             email: item['authorEmail'].strip
           })


### PR DESCRIPTION
`item['msg']` on Jenkins API is actually the title of the commit. The full commit message can be taken from `item['comment']`.